### PR TITLE
docs: fix wrong import in instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ If you have global decorators/parameters/etc and want them applied to your stori
 
 ```tsx
 // setupFile.js <-- this will run before the tests in jest.
-import { setGlobalConfig } from '@storybook/react';
+import { setGlobalConfig } from '@storybook/testing-react';
 import * as globalStorybookConfig from './.storybook/preview'; // path of your preview.js file
 
 setGlobalConfig(globalStorybookConfig);


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.0.5--canary.3.c4b5d5e.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @storybook/testing-react@0.0.5--canary.3.c4b5d5e.0
  # or 
  yarn add @storybook/testing-react@0.0.5--canary.3.c4b5d5e.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
