### PR TITLE
chore: update package url

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "typings": "dist/index.d.ts",
   "repository": {
     "type": "git",
-    "url": "https://github.com/storybookjs/react-testing"
+    "url": "https://github.com/storybookjs/testing-react"
   },
   "files": [
     "dist",
@@ -49,11 +49,11 @@
   "module": "dist/testing-utilities.esm.js",
   "size-limit": [
     {
-      "path": "dist/react-testing.cjs.production.min.js",
+      "path": "dist/testing-react.cjs.production.min.js",
       "limit": "10 KB"
     },
     {
-      "path": "dist/react-testing.esm.js",
+      "path": "dist/testing-react.esm.js",
       "limit": "10 KB"
     }
   ],


### PR DESCRIPTION
It was still using the old url!
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.0.8--canary.10.629757d.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @storybook/testing-react@0.0.8--canary.10.629757d.0
  # or 
  yarn add @storybook/testing-react@0.0.8--canary.10.629757d.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
