### PR TITLE
fix: support addons that use channel api

### DIFF
--- a/example/src/stories/Button.test.tsx
+++ b/example/src/stories/Button.test.tsx
@@ -1,5 +1,7 @@
 import React from 'react';
+import addons, { useChannel } from '@storybook/addons';
 import { render, screen } from '@testing-library/react';
+
 import { composeStories, composeStory } from '../../../dist/index';
 
 import * as stories from './Button.stories';
@@ -57,5 +59,19 @@ describe('GlobalConfig', () => {
     const buttonElement = getByText('Olá!');
     expect(buttonElement).not.toBeNull();
   });
+});
 
-})
+// common in addons that need to communicate between manager and preview
+test('should pass with decorators that ne addons channel', () => {
+  const PrimaryWithChannels = composeStory(stories.Primary, stories.default, {
+    decorators: [
+      (StoryFn: any) => {
+        addons.getChannel();
+        return <StoryFn />;
+      },
+    ],
+  });
+  render(<PrimaryWithChannels>Hello world</PrimaryWithChannels>);
+  const buttonElement = screen.getByText(/Hello world/i);
+  expect(buttonElement).not.toBeNull();
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,11 @@
 import { defaultDecorateStory, combineParameters } from '@storybook/client-api';
+import addons, { mockChannel } from '@storybook/addons';
 import type { Meta, Story, StoryContext } from '@storybook/react';
+
 import type { GlobalConfig, StoriesWithPartialProps } from './types';
+
+// Some addons use the channel api to communicate between manager/preview, and this is a client only feature, therefore we must mock it.
+addons.setChannel(mockChannel());
 
 let globalStorybookConfig = {};
 


### PR DESCRIPTION
issue: #13
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.0.10--canary.14.4ab5831.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @storybook/testing-react@0.0.10--canary.14.4ab5831.0
  # or 
  yarn add @storybook/testing-react@0.0.10--canary.14.4ab5831.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
