### PR TITLE
fix: Remove deep import StoryFnReactReturnType from @storybook/react

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,9 @@
     "analyze": "size-limit --why",
     "release": "yarn build && auto shipit"
   },
-  "peerDependencies": {},
+  "peerDependencies": {
+    "react": "^16.8.0 || ^17.0.0"
+  },
   "husky": {
     "hooks": {
       "pre-commit": "tsdx lint"

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,8 @@
 import { ArgTypes, Parameters, BaseDecorators } from '@storybook/addons';
 import type { Story } from '@storybook/react';
-import { StoryFnReactReturnType } from '@storybook/react/dist/client/preview/types';
+import { ReactElement } from 'react';
+
+type StoryFnReactReturnType = ReactElement<unknown>;
 
 /**
  * Object representing the preview.ts module


### PR DESCRIPTION
It appears the import path used for `StoryFnReactReturnType` no longer exists in `@storybook/react` from `6.2` and onwards.
This is causing a type error when used externally.

As this type is only `ReactElement<unknown>` I thought it would be better to inline this and avoid a deep import.