### PR TITLE
fix: module field should point to a real file

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "trailingComma": "es5"
   },
   "author": "yannbf@gmail.com",
-  "module": "dist/testing-utilities.esm.js",
+  "module": "dist/testing-react.esm.js",
   "size-limit": [
     {
       "path": "dist/testing-react.cjs.production.min.js",


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.0.12--canary.21.ebe57b5.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @storybook/testing-react@0.0.12--canary.21.ebe57b5.0
  # or 
  yarn add @storybook/testing-react@0.0.12--canary.21.ebe57b5.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
