### PR TITLE
fix: ignore __esModules flag when composing stories

### DIFF
--- a/example/src/stories/Button.test.tsx
+++ b/example/src/stories/Button.test.tsx
@@ -62,7 +62,7 @@ describe('GlobalConfig', () => {
 });
 
 // common in addons that need to communicate between manager and preview
-test('should pass with decorators that ne addons channel', () => {
+test('should pass with decorators that need addons channel', () => {
   const PrimaryWithChannels = composeStory(stories.Primary, stories.default, {
     decorators: [
       (StoryFn: any) => {
@@ -74,6 +74,18 @@ test('should pass with decorators that ne addons channel', () => {
   render(<PrimaryWithChannels>Hello world</PrimaryWithChannels>);
   const buttonElement = screen.getByText(/Hello world/i);
   expect(buttonElement).not.toBeNull();
+});
+
+it('should ignore __esModules property from jest mocking', () => {
+  const mockedModule = {
+    __esModule: true,
+    default: { title: 'Components/Button' },
+    Primary: () => {},
+  };
+
+  expect(() => {
+    composeStories(mockedModule)
+  }).not.toThrow();
 });
 
 describe('Unsupported formats', () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -148,9 +148,9 @@ export function composeStory<GenericArgs>(
  * @param [globalConfig] - e.g. (import * as globalConfig from '../.storybook/preview') this can be applied automatically if you use `setGlobalConfig` in your setup files.
  */
 export function composeStories<
-  T extends { default: Meta }
+  T extends { default: Meta, __esModule?: boolean }
 >(storiesImport: T, globalConfig?: GlobalConfig) {
-  const { default: meta, ...stories } = storiesImport;
+  const { default: meta, __esModule, ...stories } = storiesImport;
 
   // Compose an object containing all processed stories passed as parameters
   const composedStories = Object.entries(stories).reduce(


### PR DESCRIPTION
Issue: #12 

Jest and babel add a flag to help with mocking which impacts composeStories, that should be ignored!