### PR TITLE
Widen peer dependency range to include prereleases

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,10 +70,10 @@
     "typescript": "^4.2.3"
   },
   "peerDependencies": {
-    "react": ">=16.8.0",
-    "@storybook/react": ">=6.0.0",
-    "@storybook/addons": ">=6.0.0",
-    "@storybook/client-api": ">=6.0.0"
+    "react": "^16.8.0 || ^17.0.0",
+    "@storybook/react": "^6 || >=6.0.0-0 || >=6.1.0-0 || >=6.2.0-0 || >=6.3.0-0 ",
+    "@storybook/addons": "^6 || >=6.0.0-0 || >=6.1.0-0 || >=6.2.0-0 || >=6.3.0-0 ",
+    "@storybook/client-api": "^6 || >=6.0.0-0 || >=6.1.0-0 || >=6.2.0-0 || >=6.3.0-0 "
   },
   "resolutions": {
     "**/typescript": "^4.2.3"

--- a/package.json
+++ b/package.json
@@ -70,10 +70,10 @@
     "typescript": "^4.2.3"
   },
   "peerDependencies": {
-    "react": "^16.8.0 || ^17.0.0",
-    "@storybook/react": "^6.0.0",
-    "@storybook/addons": "^6.0.0",
-    "@storybook/client-api": "^6.0.0"
+    "react": ">=16.8.0",
+    "@storybook/react": ">=6.0.0",
+    "@storybook/addons": ">=6.0.0",
+    "@storybook/client-api": ">=6.0.0"
   },
   "resolutions": {
     "**/typescript": "^4.2.3"


### PR DESCRIPTION
Fixes #25 

This uses a more liberal `>=` semver range for peer dependencies, to allow installations with pre-release versions of storybook (and react for that matter) with npm 7.  It's also just good practice to be as open as possible with peer dependencies, to avoid problems like reach-router has right now (https://github.com/reach/router/pull/432#issuecomment-734891630)

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.0.17--canary.26.e11efee.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @storybook/testing-react@0.0.17--canary.26.e11efee.0
  # or 
  yarn add @storybook/testing-react@0.0.17--canary.26.e11efee.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
