### PR TITLE
More info about the TS setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,8 @@ Primary.args = {
 };
 ```
 
+You should use TypeScript version >4. You will also need to add `strictBindCallApply: true` in your `tsconfig.json`, and verify that stories are correctly included in your `tsconfig.json`. To do so, run `tsc --listFiles | grep stories`, you should see your stories.
+
 ## License
 
 [MIT](./LICENSE)


### PR DESCRIPTION
I fell into those traps:
- TS must be at v4, v3 cannot understand the current typings
- stories must be included in the tsconfig for the `strictBindCallApply` option to be applied (other wise you get "any" typings)
Edit: 4.2.2 is the best version at the time of writing since there is a bug with v4.3.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.0.18--canary.29.8540aca.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @storybook/testing-react@0.0.18--canary.29.8540aca.0
  # or 
  yarn add @storybook/testing-react@0.0.18--canary.29.8540aca.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
