### PR TITLE
Fix: Use more open typings from storybook 6.3

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,6 @@
 import { defaultDecorateStory, combineParameters } from '@storybook/client-api';
 import addons, { mockChannel } from '@storybook/addons';
-import type { Meta, Story, StoryContext } from '@storybook/react';
-
+import type { ComponentMeta, ComponentStory, StoryContext } from '@storybook/react';
 import type { GlobalConfig, StoriesWithPartialProps, BaseStoryFn } from './types';
 import { globalRender, isInvalidStory } from './utils';
 
@@ -55,9 +54,9 @@ export function setGlobalConfig(config: GlobalConfig) {
  * @param meta - e.g. (import Meta from './Button.stories')
  * @param [globalConfig] - e.g. (import * as globalConfig from '../.storybook/preview') this can be applied automatically if you use `setGlobalConfig` in your setup files.
  */
-export function composeStory<GenericArgs>(
-  story: Story<GenericArgs>,
-  meta: Meta,
+export function composeStory(
+  story: ComponentStory<any>,
+  meta: ComponentMeta<any>,
   globalConfig: GlobalConfig = globalStorybookConfig
 ) {
 
@@ -82,9 +81,9 @@ export function composeStory<GenericArgs>(
       );
     }
 
-    const renderFn = typeof story === 'function' ?  story : story.render ?? globalRender as BaseStoryFn<GenericArgs>;
+    const renderFn = typeof story === 'function' ?  story : story.render ?? globalRender as BaseStoryFn<any>;
 
-    return renderFn(context.args as GenericArgs, context);
+    return renderFn(context.args, context);
   };
 
   const combinedDecorators = [
@@ -141,7 +140,7 @@ export function composeStory<GenericArgs>(
   composedStory.decorators = combinedDecorators
   composedStory.parameters = combinedParameters
 
-  return composedStory as BaseStoryFn<Partial<GenericArgs>>;
+  return composedStory as ComponentStory<any>;
 }
 
 /**
@@ -170,17 +169,17 @@ export function composeStory<GenericArgs>(
  * @param [globalConfig] - e.g. (import * as globalConfig from '../.storybook/preview') this can be applied automatically if you use `setGlobalConfig` in your setup files.
  */
 export function composeStories<
-  T extends { default: Meta, __esModule?: boolean }
+  T extends { default: ComponentMeta<any>, __esModule?: boolean }
 >(storiesImport: T, globalConfig?: GlobalConfig) {
   const { default: meta, __esModule, ...stories } = storiesImport;
 
   // Compose an object containing all processed stories passed as parameters
   const composedStories = Object.entries(stories).reduce(
     (storiesMap, [key, story]) => {
-      storiesMap[key] = composeStory(story as Story, meta, globalConfig);
+      storiesMap[key] = composeStory(story as ComponentStory<any>, meta, globalConfig);
       return storiesMap;
     },
-    {} as { [key: string]: Story }
+    {} as { [key: string]: ComponentStory<any> }
   );
 
   return composedStories as StoriesWithPartialProps<T>;

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,5 @@
 import { ArgTypes, Parameters, BaseDecorators, BaseAnnotations, BaseStoryFn as OriginalBaseStoryFn } from '@storybook/addons';
-import type { Story } from '@storybook/react';
+import type { ComponentStory } from '@storybook/react';
 import { ReactElement } from 'react';
 
 type StoryFnReactReturnType = ReactElement<unknown>;
@@ -25,5 +25,5 @@ export type GlobalConfig = {
  * 3. reconstruct Story with Partial. Story<Props> -> Story<Partial<Props>>
  */
 export type StoriesWithPartialProps<T> = { 
-  [K in keyof T as T[K] extends Story<any> ? K : never]: T[K] extends Story<infer P> ? BaseStoryFn<Partial<P>> : unknown 
+  [K in keyof T as T[K] extends ComponentStory<any> ? K : never]: T[K] extends ComponentStory<infer P> ? BaseStoryFn<Partial<P>> : unknown 
 }


### PR DESCRIPTION
I recently realized that Storybook/react 6.3 introduced replacements for the Story & Meta-types - called ComponentStory & ComponentMeta (see storybookjs/storybook#14780). F.e.:

````
export const Defaults: ComponentStory<typeof Button> = {
  args: { children: "My Button" },
};
````

I updated the typings everywhere but, as I'm not used to authoring libs which support a broader version-range, I'm unsure if we need to support both Story/ComponentStory- & Meta/ComponentMeta-types at every occurance of those types or if the more open types of 6.3 are enough?

So if we need to support both, I'll gladly take advice on this question and update the PR!

