### PR TITLE
feat: add storyName to composed story

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,6 +198,25 @@ test('renders with play function', async () => {
 });
 ```
 
+## Batch testing all stories from a file
+
+Rather than specifying test by test manually, you can also run automated tests by using [test.each](https://jestjs.io/docs/api#testeachtablename-fn-timeout) in combination with `composeStories`. Here's an example for doing snapshot tests in all stories from a file:
+
+```js
+import * as stories from './Button.stories';
+
+const testCases = Object.values(composeStories(stories)).map((Story) => [
+  // The ! is necessary in Typescript only, as the property is part of a partial type
+  Story.storyName!,
+  Story,
+]);
+// Batch snapshot testing
+test.each(testCases)('Renders %s story', async (_storyName, Story) => {
+  const tree = await render(<Story />);
+  expect(tree.baseElement).toMatchSnapshot();
+});
+```
+
 ## Typescript
 
 `@storybook/testing-react` is typescript ready and provides autocompletion to easily detect all stories of your component:

--- a/example/src/__snapshots__/internals.test.tsx.snap
+++ b/example/src/__snapshots__/internals.test.tsx.snap
@@ -1,0 +1,122 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Renders CSF3Button story 1`] = `
+<body>
+  <div>
+    <div>
+      Locale: 
+      en
+    </div>
+    <button
+      class="storybook-button storybook-button--medium storybook-button--secondary"
+      type="button"
+    >
+      foo
+    </button>
+  </div>
+</body>
+`;
+
+exports[`Renders CSF3ButtonWithRender story 1`] = `
+<body>
+  <div>
+    <div>
+      Locale: 
+      en
+    </div>
+    <div>
+      <p
+        data-testid="custom-render"
+      >
+        I am a custom render function
+      </p>
+      <button
+        class="storybook-button storybook-button--medium storybook-button--secondary"
+        type="button"
+      >
+        foo
+      </button>
+    </div>
+  </div>
+</body>
+`;
+
+exports[`Renders InputFieldFilled story 1`] = `
+<body>
+  <div>
+    <div>
+      Locale: 
+      en
+    </div>
+    <input />
+  </div>
+</body>
+`;
+
+exports[`Renders Primary story 1`] = `
+<body>
+  <div>
+    <div>
+      Locale: 
+      en
+    </div>
+    <button
+      class="storybook-button storybook-button--large storybook-button--primary"
+      type="button"
+    >
+      foo
+    </button>
+  </div>
+</body>
+`;
+
+exports[`Renders Secondary story 1`] = `
+<body>
+  <div>
+    <div>
+      Locale: 
+      en
+    </div>
+    <button
+      class="storybook-button storybook-button--medium storybook-button--secondary"
+      type="button"
+    >
+      Children coming from story args!
+    </button>
+  </div>
+</body>
+`;
+
+exports[`Renders StoryWithParamsAndDecorator story 1`] = `
+<body>
+  <div>
+    <div>
+      Locale: 
+      en
+    </div>
+    <button
+      class="storybook-button storybook-button--medium storybook-button--secondary"
+      type="button"
+    >
+      foo
+    </button>
+  </div>
+</body>
+`;
+
+exports[`Renders WithLocale story 1`] = `
+<body>
+  <div>
+    <div>
+      Locale: 
+      en
+    </div>
+    <button
+      class="storybook-button storybook-button--medium storybook-button--secondary"
+      type="button"
+    >
+      Hello!
+    </button>
+  </div>
+</body>
+`;

--- a/example/src/components/Button.stories.tsx
+++ b/example/src/components/Button.stories.tsx
@@ -49,6 +49,7 @@ export const StoryWithLocale: CSF2Story = (args, { globals: { locale } }) => {
   const caption = getCaptionForLocale(locale);
   return <Button>{caption}</Button>;
 };
+StoryWithLocale.storyName = 'WithLocale'
 
 export const StoryWithParamsAndDecorator: CSF2Story<ButtonProps> = args => {
   return <Button {...args} />;

--- a/example/src/internals.test.tsx
+++ b/example/src/internals.test.tsx
@@ -91,3 +91,14 @@ describe('non-story exports', () => {
     expect(Object.keys(result)).not.toContain('mockData');
   });
 })
+
+// Batch snapshot testing
+const testCases = Object.values(composeStories(stories)).map((Story) => [
+  // The ! is necessary in Typescript only, as the property is part of a partial type
+  Story.storyName!,
+  Story,
+])
+test.each(testCases)('Renders %s story', async (_storyName, Story) => {
+  const tree = await render(<Story />)
+  expect(tree.baseElement).toMatchSnapshot()
+})

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,5 @@
 import { ArgTypes, Parameters, BaseDecorators, BaseAnnotations, BaseStoryFn as OriginalBaseStoryFn } from '@storybook/addons';
-import type { StoryFn, StoryObj, Meta } from '@storybook/react';
+import type { StoryFn, StoryObj, Meta, Args } from '@storybook/react';
 import { ReactElement } from 'react';
 
 type StoryFnReactReturnType = ReactElement<unknown>;
@@ -18,7 +18,7 @@ export type GlobalConfig = {
   [key: string]: any;
 };
 
-export type TestingStory<T> = StoryFn<T> | StoryObj<T>;
+export type TestingStory<T = Args> = StoryFn<T> | StoryObj<T>;
 
 export type StoryFile = { default: Meta, __esModule?: boolean }
 /**

--- a/src/utils.tsx
+++ b/src/utils.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 
 import type { FunctionComponent } from 'react';
 import type { Story } from '@storybook/react';
+import type { TestingStory } from './types';
 
 export const globalRender: Story = (args, { parameters }) => {
   if (!parameters.component) {
@@ -24,4 +25,16 @@ type Entries<T> = {
 }[keyof T];
 export function objectEntries<T extends object>(t: T): Entries<T>[] {
   return Object.entries(t) as any;
+}
+
+export const getStoryName = (story: TestingStory) => {
+  if(story.storyName) {
+    return story.storyName
+  }
+
+  if(typeof story !== 'function' && story.name) {
+    return story.name
+  }
+
+  return undefined
 }


### PR DESCRIPTION
Issue: #49

## What Changed

The composedStory now contains the `storyName` property, which comes from:
- Story.storyName. If undefined, 
- Story.name (if using CSF1 or CSF2). If undefined,
- The exported key name from the stories module

Also added a recipe for automated testing, thanks a lot @synaptiko

## Checklist

Check the ones applicable to your change:

- [x] Tests are updated
- [x] Documentation is updated

## Change Type

Indicate the type of change your pull request is:

- [ ] `documentation`
- [x] `patch`
- [ ] `minor`
- [ ] `major`
