### PR TITLE
Fix/component meta typing

### DIFF
--- a/example/src/components/AccountForm.stories.tsx
+++ b/example/src/components/AccountForm.stories.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import type { ComponentMeta } from '@storybook/react';
+import type { ComponentMeta, ComponentStoryObj } from '@storybook/react';
 import { screen } from '@testing-library/dom';
 import userEvent from '@testing-library/user-event';
 
@@ -13,17 +13,18 @@ export default {
   },
 } as ComponentMeta<typeof AccountForm>;
 
+type Story = ComponentStoryObj<typeof AccountForm>
 
-export const Standard = {
+export const Standard: Story = {
   args: { passwordVerification: false },
 };
 
-export const StandardEmailFilled = {
+export const StandardEmailFilled: Story = {
   ...Standard,
   play: () => userEvent.type(screen.getByTestId('email'), 'michael@chromatic.com'),
 };
 
-export const StandardEmailFailed = {
+export const StandardEmailFailed: Story = {
   ...Standard,
   play: async () => {
     await userEvent.type(screen.getByTestId('email'), 'michael@chromatic.com.com@com');
@@ -32,41 +33,41 @@ export const StandardEmailFailed = {
   },
 };
 
-export const StandardPasswordFailed = {
+export const StandardPasswordFailed: Story = {
   ...Standard,
-  play: async () => {
-    await StandardEmailFilled.play();
+  play: async (context) => {
+    await StandardEmailFilled.play!(context);
     await userEvent.type(screen.getByTestId('password1'), 'asdf');
     await userEvent.click(screen.getByTestId('submit'));
   },
 };
 
-export const StandardFailHover = {
+export const StandardFailHover: Story = {
   ...StandardPasswordFailed,
-  play: async () => {
-    await StandardPasswordFailed.play();
+  play: async (context) => {
+    await StandardPasswordFailed.play!(context);
     await sleep(100);
     await userEvent.hover(screen.getByTestId('password-error-info'));
   },
 };
 
-export const Verification = {
+export const Verification: Story = {
   args: { passwordVerification: true },
 };
 
-export const VerificationPasssword1 = {
+export const VerificationPasssword1: Story = {
   ...Verification,
-  play: async () => {
-    await StandardEmailFilled.play();
+  play: async (context) => {
+    await StandardEmailFilled.play!(context);
     await userEvent.type(screen.getByTestId('password1'), 'asdfasdf');
     await userEvent.click(screen.getByTestId('submit'));
   },
 };
 
-export const VerificationPasswordMismatch = {
+export const VerificationPasswordMismatch: Story = {
   ...Verification,
-  play: async () => {
-    await StandardEmailFilled.play();
+  play: async (context) => {
+    await StandardEmailFilled.play!(context);
     await userEvent.type(screen.getByTestId('password1'), 'asdfasdf');
     await userEvent.type(screen.getByTestId('password2'), 'asdf1234');
     await userEvent.click(screen.getByTestId('submit'));
@@ -75,10 +76,10 @@ export const VerificationPasswordMismatch = {
 
 const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
 
-export const VerificationSuccess = {
+export const VerificationSuccess: Story = {
   ...Verification,
-  play: async () => {
-    await StandardEmailFilled.play();
+  play: async (context) => {
+    await StandardEmailFilled.play!(context);
     await sleep(1000);
     await userEvent.type(screen.getByTestId('password1'), 'asdfasdf', { delay: 50 });
     await sleep(1000);
@@ -88,7 +89,7 @@ export const VerificationSuccess = {
   },
 };
 
-export const StandardWithRenderFunction = {
+export const StandardWithRenderFunction: Story = {
   ...Standard,
   render: (args: AccountFormProps) => (<div>
     <p>This uses a custom render</p>

--- a/example/src/components/AccountForm.test.tsx
+++ b/example/src/components/AccountForm.test.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+
+import { composeStories, composeStory } from '../../../dist/index';
+
+import * as stories from './AccountForm.stories';
+
+const { Standard } = composeStories(stories)
+
+test('renders form', async () => {
+  await render(<Standard />)
+})
+
+test('fills input from play function', async () => {
+  const StandardEmailFilled = composeStory(
+    stories.StandardEmailFilled, 
+    stories.default
+  )
+  const { container } = await render(<StandardEmailFilled />)
+
+  await StandardEmailFilled.play({ canvasElement: container })
+
+  const emailInput = screen.getByTestId('email') as HTMLInputElement;
+  expect(emailInput.value).toBe('michael@chromatic.com')
+})

--- a/src/index.ts
+++ b/src/index.ts
@@ -149,7 +149,6 @@ export function composeStory<GenericArgs>(
   }
 
   const boundPlay = ({ ...extraContext }: TestingStoryPlayContext<GenericArgs>) => {
-    console.log('calling boundplay')
     return story.play?.({ ...context, ...extraContext });
   }
   

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,7 +3,7 @@ import addons, { mockChannel } from '@storybook/addons';
 import type { Meta, StoryContext, ReactFramework } from '@storybook/react';
 import { isExportStory } from '@storybook/csf'
 
-import type { GlobalConfig, StoriesWithPartialProps, StoryFile, TestingStory } from './types';
+import type { GlobalConfig, StoriesWithPartialProps, StoryFile, TestingStory, TestingStoryPlayContext } from './types';
 import { getStoryName, globalRender, isInvalidStory, objectEntries } from './utils';
 
 // Some addons use the channel api to communicate between manager/preview, and this is a client only feature, therefore we must mock it.
@@ -62,7 +62,7 @@ export function setGlobalConfig(config: GlobalConfig) {
  */
 export function composeStory<GenericArgs>(
   story: TestingStory<GenericArgs>,
-  meta: Meta,
+  meta: Meta<GenericArgs | any>,
   globalConfig: GlobalConfig = globalStorybookConfig
 ) {
 
@@ -148,8 +148,9 @@ export function composeStory<GenericArgs>(
     })
   }
 
-  const boundPlay = ({ ...extraContext }: Partial<StoryContext<ReactFramework, GenericArgs>> & Pick<StoryContext, 'canvasElement'>) => {
-    story.play?.({ ...context, ...extraContext });
+  const boundPlay = ({ ...extraContext }: TestingStoryPlayContext<GenericArgs>) => {
+    console.log('calling boundplay')
+    return story.play?.({ ...context, ...extraContext });
   }
   
   composedStory.storyName = story.storyName || story.name

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,6 @@
 import { ArgTypes, Parameters, BaseDecorators, BaseAnnotations, BaseStoryFn as OriginalBaseStoryFn } from '@storybook/addons';
-import type { StoryFn, StoryObj, Meta, Args } from '@storybook/react';
+import { PlayFunction } from '@storybook/csf';
+import type { StoryFn as OriginalStoryFn, StoryObj, Meta, Args,StoryContext, ReactFramework } from '@storybook/react';
 import { ReactElement } from 'react';
 
 type StoryFnReactReturnType = ReactElement<unknown>;
@@ -20,7 +21,14 @@ export type GlobalConfig = {
 
 export type TestingStory<T = Args> = StoryFn<T> | StoryObj<T>;
 
-export type StoryFile = { default: Meta, __esModule?: boolean }
+export type StoryFile = { default: Meta<any>, __esModule?: boolean }
+
+export type TestingStoryPlayContext<T = Args> = Partial<StoryContext<ReactFramework, T>> & Pick<StoryContext, 'canvasElement'>
+
+export type TestingStoryPlayFn<TArgs = Args> = (context: TestingStoryPlayContext<TArgs>) => Promise<void> | void;
+
+export type StoryFn<TArgs = Args> = OriginalStoryFn<TArgs> & { play: TestingStoryPlayFn<TArgs> }
+
 /**
  * T represents the whole es module of a stories file. K of T means named exports (basically the Story type)
  * 1. pick the keys K of T that have properties that are Story<AnyProps>


### PR DESCRIPTION
Issue: #62 

## What Changed

This PR fixes the compatibility with parameterized Meta (or ComponentMeta) as well as the play function type issue coming from `composeStories`

## Checklist

Check the ones applicable to your change:

- [x] Tests are updated
- [ ] Documentation is updated

## Change Type

Indicate the type of change your pull request is:

- [ ] `documentation`
- [x] `patch`
- [ ] `minor`
- [ ] `major`

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>1.2.1--canary.73.837969a.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @storybook/testing-react@1.2.1--canary.73.837969a.0
  # or 
  yarn add @storybook/testing-react@1.2.1--canary.73.837969a.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
