### PR TITLE
fix: align global config types with Storybook 6.4

### DIFF
--- a/example/.storybook/preview.tsx
+++ b/example/.storybook/preview.tsx
@@ -1,19 +1,19 @@
 import React from 'react';
-import type { Story } from '@storybook/react';
+import type { DecoratorFn } from '@storybook/react';
 import { ThemeProvider, convert, themes } from '@storybook/theming';
 
 export const parameters = {
   actions: { argTypesRegex: '^on[A-Z].*' }
 }
 
-export const decorators = [
-  (StoryFn: Story, { globals: { locale } }) => (
+export const decorators: DecoratorFn[] = [
+  (StoryFn, { globals: { locale } }) => (
     <>
       <div>Locale: {locale}</div>
       <StoryFn />
     </>
   ),
-  (StoryFn: Story) => (
+  (StoryFn) => (
     <ThemeProvider theme={convert(themes.light)}>
       <StoryFn />
     </ThemeProvider>

--- a/example/setup.ts
+++ b/example/setup.ts
@@ -1,4 +1,3 @@
-//@ts-nocheck
 import { setGlobalConfig } from '../dist/index';
 import * as globalStorybookConfig from './.storybook/preview';
 

--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
   "peerDependencies": {
     "@storybook/addons": ">=6.4.0-0",
     "@storybook/client-api": ">=6.4.0-0",
+    "@storybook/preview-web": ">=6.4.0-0",
     "@storybook/react": ">=6.4.0-0",
     "react": "^16.8.0 || ^17.0.0"
   },

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,7 +1,7 @@
-import { ArgTypes, Parameters, BaseDecorators, BaseAnnotations, BaseStoryFn as OriginalBaseStoryFn } from '@storybook/addons';
-import { PlayFunction } from '@storybook/csf';
+import type { BaseAnnotations, BaseStoryFn as OriginalBaseStoryFn } from '@storybook/addons';
+import type { WebProjectAnnotations } from '@storybook/preview-web';
 import type { StoryFn as OriginalStoryFn, StoryObj, Meta, Args,StoryContext, ReactFramework } from '@storybook/react';
-import { ReactElement } from 'react';
+import type { ReactElement } from 'react';
 
 type StoryFnReactReturnType = ReactElement<unknown>;
 
@@ -12,12 +12,7 @@ export type BaseStoryFn<Args> = OriginalBaseStoryFn<Args, StoryFnReactReturnType
  * Used in storybook testing utilities.
  * @see [Unit testing with Storybook](https://storybook.js.org/docs/react/workflows/unit-testing)
  */
-export type GlobalConfig = {
-  decorators?: BaseDecorators<StoryFnReactReturnType>;
-  parameters?: Parameters;
-  argTypes?: ArgTypes;
-  [key: string]: any;
-};
+export type GlobalConfig = WebProjectAnnotations<ReactFramework>;
 
 export type TestingStory<T = Args> = StoryFn<T> | StoryObj<T>;
 


### PR DESCRIPTION
Issue: #61 

## What Changed

The globalconfig types now come from Storybook 6.4

## Checklist

Check the ones applicable to your change:

- [ ] Tests are updated
- [ ] Documentation is updated

## Change Type

Indicate the type of change your pull request is:

- [ ] `documentation`
- [x] `patch`
- [ ] `minor`
- [ ] `major`
