### PR TITLE
Restructure internals of library to use @storybook/store logic

### DIFF
--- a/example/src/__snapshots__/internals.test.tsx.snap
+++ b/example/src/__snapshots__/internals.test.tsx.snap
@@ -9,6 +9,7 @@ exports[`Renders CSF3Button story 1`] = `
     </div>
     <button
       class="storybook-button storybook-button--medium storybook-button--secondary"
+      label="Button"
       type="button"
     >
       foo
@@ -32,6 +33,7 @@ exports[`Renders CSF3ButtonWithRender story 1`] = `
       </p>
       <button
         class="storybook-button storybook-button--medium storybook-button--secondary"
+        label="Button"
         type="button"
       >
         foo
@@ -62,6 +64,7 @@ exports[`Renders Primary story 1`] = `
     </div>
     <button
       class="storybook-button storybook-button--large storybook-button--primary"
+      label="Button"
       type="button"
     >
       foo
@@ -79,9 +82,27 @@ exports[`Renders Secondary story 1`] = `
     </div>
     <button
       class="storybook-button storybook-button--medium storybook-button--secondary"
+      label="Button"
       type="button"
     >
       Children coming from story args!
+    </button>
+  </div>
+</body>
+`;
+
+exports[`Renders StoryWithLocale story 1`] = `
+<body>
+  <div>
+    <div>
+      Locale: 
+      en
+    </div>
+    <button
+      class="storybook-button storybook-button--medium storybook-button--secondary"
+      type="button"
+    >
+      Hello!
     </button>
   </div>
 </body>
@@ -96,26 +117,10 @@ exports[`Renders StoryWithParamsAndDecorator story 1`] = `
     </div>
     <button
       class="storybook-button storybook-button--medium storybook-button--secondary"
+      label="Button"
       type="button"
     >
       foo
-    </button>
-  </div>
-</body>
-`;
-
-exports[`Renders WithLocale story 1`] = `
-<body>
-  <div>
-    <div>
-      Locale: 
-      en
-    </div>
-    <button
-      class="storybook-button storybook-button--medium storybook-button--secondary"
-      type="button"
-    >
-      Hello!
     </button>
   </div>
 </body>

--- a/example/src/components/Button.test.tsx
+++ b/example/src/components/Button.test.tsx
@@ -49,10 +49,11 @@ describe('GlobalConfig', () => {
     expect(buttonElement).not.toBeNull();
   });
 
-  test.skip('renders with custom globalConfig', () => {
+  test('renders with custom globalConfig', () => {
     const WithPortugueseText = composeStory(
       stories.StoryWithLocale,
       stories.default,
+      // @ts-ignore
       { globalTypes: { locale: { defaultValue: 'pt' } } }
     );
     const { getByText } = render(<WithPortugueseText />);

--- a/example/src/components/Button.test.tsx
+++ b/example/src/components/Button.test.tsx
@@ -49,7 +49,7 @@ describe('GlobalConfig', () => {
     expect(buttonElement).not.toBeNull();
   });
 
-  test('renders with custom globalConfig', () => {
+  test.skip('renders with custom globalConfig', () => {
     const WithPortugueseText = composeStory(
       stories.StoryWithLocale,
       stories.default,

--- a/example/src/internals.test.tsx
+++ b/example/src/internals.test.tsx
@@ -9,17 +9,20 @@ import * as globalConfig from '../.storybook/preview';
 
 const { StoryWithParamsAndDecorator } = composeStories(stories);
 
-test('returns composed parameters from story', () => {
-  expect(StoryWithParamsAndDecorator.args).toEqual(stories.StoryWithParamsAndDecorator.args);
-  expect(StoryWithParamsAndDecorator.parameters).toEqual({
-    ...stories.StoryWithParamsAndDecorator.parameters,
-    ...globalConfig.parameters,
-    component: stories.default.component
+test('returns composed args including default values from argtypes', () => {
+  expect(StoryWithParamsAndDecorator.args).toEqual({
+    ...stories.StoryWithParamsAndDecorator.args,
+    label: stories.default!.argTypes!.label!.defaultValue
   });
-  expect(StoryWithParamsAndDecorator.decorators).toEqual([
-    ...stories.StoryWithParamsAndDecorator.decorators!,
-    ...globalConfig.decorators,
-  ]);
+})
+
+test('returns composed parameters from story', () => {
+  expect(StoryWithParamsAndDecorator.parameters).toEqual(
+    expect.objectContaining({
+      ...stories.StoryWithParamsAndDecorator.parameters,
+      ...globalConfig.parameters,
+    })
+  );
 });
 
 // common in addons that need to communicate between manager and preview
@@ -68,6 +71,7 @@ describe('non-story exports', () => {
   test('should filter non-story exports with excludeStories', () => {
     const StoryModuleWithNonStoryExports = {
       default: {
+        title: 'Some/Component',
         excludeStories: /.*Data/
       },
       LegitimateStory: () => <div>hello world</div>,
@@ -81,6 +85,7 @@ describe('non-story exports', () => {
   test('should filter non-story exports with includeStories', () => {
     const StoryModuleWithNonStoryExports = {
       default: {
+        title: 'Some/Component',
         includeStories: /.*Story/
       },
       LegitimateStory: () => <div>hello world</div>,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,9 +1,10 @@
 import addons, { mockChannel } from '@storybook/addons';
-import type { Meta } from '@storybook/react';
+import type { Meta, ReactFramework } from '@storybook/react';
+import { isExportStory } from '@storybook/csf';
+import { composeConfigs, WebProjectAnnotations } from '@storybook/preview-web';
 
 import type { GlobalConfig, StoriesWithPartialProps, StoryFile, TestingStory } from './types';
 import { objectEntries, globalRender } from './utils';
-import { isExportStory } from '@storybook/csf';
 
 // @TODO: These helpers have to be exposed properly in @storybook/store
 //@ts-ignore
@@ -18,7 +19,7 @@ import { HooksContext } from '@storybook/store/dist/cjs/hooks'
 // Some addons use the channel api to communicate between manager/preview, and this is a client only feature, therefore we must mock it.
 addons.setChannel(mockChannel());
 
-const defaultGlobalConfig = {
+const defaultGlobalConfig: WebProjectAnnotations<ReactFramework> = {
   // @TODO: using render from @storybook/react throws
   // Cannot find module 'react-dom' from 'render.js'
   render: globalRender
@@ -44,9 +45,8 @@ let globalStorybookConfig = {
  * @param config - e.g. (import * as globalConfig from '../.storybook/preview')
  */
 export function setGlobalConfig(config: GlobalConfig) {
-  globalStorybookConfig = {...defaultGlobalConfig, ...config};
+  globalStorybookConfig = composeConfigs([defaultGlobalConfig, config]);
 }
-
 
 /**
  * Function that will receive a story along with meta (e.g. a default export from a .stories file)
@@ -91,7 +91,7 @@ export function composeStory<GenericArgs>(
     meta: normalizedMeta, 
     stories: normalizedStories
   } = processCSFFile({ default: meta, ...{[story.storyName!]: story} }, '', meta.title)
-  const normalizedStory = Object.values(normalizedStories)[0] as any
+  const normalizedStory = Object.values(normalizedStories)[0]
 
   const preparedStory = prepareStory(
     normalizedStory,

--- a/src/types.ts
+++ b/src/types.ts
@@ -16,7 +16,7 @@ export type GlobalConfig = WebProjectAnnotations<ReactFramework>;
 
 export type TestingStory<T = Args> = StoryFn<T> | StoryObj<T>;
 
-export type StoryFile = { default: Meta<any>, __esModule?: boolean }
+export type StoryFile = { default: Meta<any>, __esModule?: boolean, __namedExportsOrder?: any }
 
 export type TestingStoryPlayContext<T = Args> = Partial<StoryContext<ReactFramework, T>> & Pick<StoryContext, 'canvasElement'>
 

--- a/src/utils.tsx
+++ b/src/utils.tsx
@@ -1,24 +1,23 @@
 import React from 'react';
 
-import type { FunctionComponent } from 'react';
-import type { Story } from '@storybook/react';
+import type { ArgsStoryFn } from '@storybook/csf';
+import type { ReactFramework } from '@storybook/react';
 import type { TestingStory } from './types';
-
-export const globalRender: Story = (args, { parameters }) => {
-  if (!parameters.component) {
-    throw new Error(`
-      Could not render story due to missing 'component' property in Meta.
-      Please refer to https://github.com/storybookjs/testing-react#csf3
-    `);
-  }
-
-  const Component = parameters.component as FunctionComponent;
-  return <Component {...args} />;
-};
 
 const invalidStoryTypes = new Set(['string', 'number', 'boolean', 'symbol']);
 
 export const isInvalidStory = (story?: any) => (!story || Array.isArray(story) || invalidStoryTypes.has(typeof story))
+
+export const globalRender: ArgsStoryFn<ReactFramework> = (args, context) => {
+  const { id, component: Component } = context;
+  if (!Component) {
+    throw new Error(
+      `Unable to render story ${id} as the component annotation is missing from the default export`
+    );
+  }
+
+  return <Component {...args} />;
+};
 
 type Entries<T> = {
   [K in keyof T]: [K, T[K]];
@@ -28,11 +27,11 @@ export function objectEntries<T extends object>(t: T): Entries<T>[] {
 }
 
 export const getStoryName = (story: TestingStory) => {
-  if(story.storyName) {
+  if (story.storyName) {
     return story.storyName
   }
 
-  if(typeof story !== 'function' && story.name) {
+  if (typeof story !== 'function' && story.name) {
     return story.name
   }
 

--- a/src/utils.tsx
+++ b/src/utils.tsx
@@ -2,11 +2,6 @@ import React from 'react';
 
 import type { ArgsStoryFn } from '@storybook/csf';
 import type { ReactFramework } from '@storybook/react';
-import type { TestingStory } from './types';
-
-const invalidStoryTypes = new Set(['string', 'number', 'boolean', 'symbol']);
-
-export const isInvalidStory = (story?: any) => (!story || Array.isArray(story) || invalidStoryTypes.has(typeof story))
 
 export const globalRender: ArgsStoryFn<ReactFramework> = (args, context) => {
   const { id, component: Component } = context;
@@ -24,16 +19,4 @@ type Entries<T> = {
 }[keyof T];
 export function objectEntries<T extends object>(t: T): Entries<T>[] {
   return Object.entries(t) as any;
-}
-
-export const getStoryName = (story: TestingStory) => {
-  if (story.storyName) {
-    return story.storyName
-  }
-
-  if (typeof story !== 'function' && story.name) {
-    return story.name
-  }
-
-  return undefined
 }


### PR DESCRIPTION
Issue: N/A

## What Changed

The @storybook/testing-* libraries have lots of redundant logic that don't follow the development speed of Storybook. This PR aims to reuse the logic from Storybook's `prepareStory` instead of reinventing the wheel.

## Checklist

These are things to do before merging this:

[ ] expose normalizeStories + normalizeComponentAnnotations from @storybook/store
[ ] instead of using processCSFFile, use normalizeStories + normalizeComponentAnnotations from @storybook/store
[ ] figure out why using render from @storybook/react throws `Cannot find module 'react-dom' from 'render.js'`

Check the ones applicable to your change:

- [x] Tests are updated
- [ ] Documentation is updated

## Change Type

Indicate the type of change your pull request is:

- [ ] `documentation`
- [ ] `patch`
- [x] `minor`
- [ ] `major`
