### PR TITLE
fix: support addons that use hook api (#30)

### DIFF
--- a/example/src/__snapshots__/internals.test.tsx.snap
+++ b/example/src/__snapshots__/internals.test.tsx.snap
@@ -87,6 +87,29 @@ exports[`Renders Secondary story 1`] = `
 </body>
 `;
 
+exports[`Renders StoryWithDecoratorUseHook story 1`] = `
+<body>
+  <div>
+    <div>
+      Locale: 
+      en
+    </div>
+    <div>
+      <div>
+        args.size:
+        large
+      </div>
+      <button
+        class="storybook-button storybook-button--large storybook-button--primary"
+        type="button"
+      >
+        foo
+      </button>
+    </div>
+  </div>
+</body>
+`;
+
 exports[`Renders StoryWithParamsAndDecorator story 1`] = `
 <body>
   <div>

--- a/example/src/components/Button.stories.tsx
+++ b/example/src/components/Button.stories.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { StoryFn as CSF2Story, StoryObj as CSF3Story, Meta } from '@storybook/react';
+import { StoryFn as CSF2Story, StoryObj as CSF3Story, Meta, ComponentStoryObj } from '@storybook/react';
+import { useArgs } from '@storybook/addons';
 import { screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
@@ -83,4 +84,21 @@ export const InputFieldFilled: CSF3Story = {
   play: async (context) => {
     await userEvent.type(screen.getByRole('textbox'), 'Hello world!');
   },
+};
+
+
+type Story = ComponentStoryObj<typeof Button>;
+
+export const StoryWithDecoratorUseHook: Story = {
+  args: {
+    children: 'foo',
+    size: 'large',
+    primary: true,
+  },
+  decorators: [
+    (Story) => {
+      const [args] = useArgs();
+      return (<div><div>args.size:{args.size}</div><Story></Story></div>)
+    }
+  ]
 };

--- a/example/src/components/Button.stories.tsx
+++ b/example/src/components/Button.stories.tsx
@@ -86,10 +86,7 @@ export const InputFieldFilled: CSF3Story = {
   },
 };
 
-
-type Story = ComponentStoryObj<typeof Button>;
-
-export const StoryWithDecoratorUseHook: Story = {
+export const StoryWithDecoratorUseHook: CSF3Story<ButtonProps> = {
   args: {
     children: 'foo',
     size: 'large',

--- a/example/src/components/Button.test.tsx
+++ b/example/src/components/Button.test.tsx
@@ -92,20 +92,25 @@ describe('CSF3', () => {
   });
 });
 
-const { StoryWithDecoratorUseHook } = composeStories(stories);
+describe('Storybook hooks api', () => {
+  const StoryWithDecoratorUseHook = composeStory(
+    stories.StoryWithDecoratorUseHook,
+    stories.default
+  );
 
-test('renders with decorator use hooks api.', () => {
-  render(<StoryWithDecoratorUseHook>Hello world</StoryWithDecoratorUseHook>);
-  const decoratorElement = screen.getByText(/args.size:large/i);
-  expect(decoratorElement).not.toBeNull();
-  const buttonElement = screen.getByText(/Hello world/i);
-  expect(buttonElement).not.toBeNull();
-});
+  test('renders with decorator use hooks api.', () => {
+    render(<StoryWithDecoratorUseHook>Hello world</StoryWithDecoratorUseHook>);
+    const decoratorElement = screen.getByText(/args.size:large/i);
+    expect(decoratorElement).not.toBeNull();
+    const buttonElement = screen.getByText(/Hello world/i);
+    expect(buttonElement).not.toBeNull();
+  });
 
-test('renders with decorator use hooks api, and args.', () => {
-  render(<StoryWithDecoratorUseHook size='small'>Hello world</StoryWithDecoratorUseHook>);
-  const decoratorElement = screen.getByText(/args.size:small/i);
-  expect(decoratorElement).not.toBeNull();
-  const buttonElement = screen.getByText(/Hello world/i);
-  expect(buttonElement).not.toBeNull();
-});
+  test('renders with decorator use hooks api, and args.', () => {
+    render(<StoryWithDecoratorUseHook size='small'>Hello world</StoryWithDecoratorUseHook>);
+    const decoratorElement = screen.getByText(/args.size:small/i);
+    expect(decoratorElement).not.toBeNull();
+    const buttonElement = screen.getByText(/Hello world/i);
+    expect(buttonElement).not.toBeNull();
+  });
+})

--- a/example/src/components/Button.test.tsx
+++ b/example/src/components/Button.test.tsx
@@ -91,3 +91,21 @@ describe('CSF3', () => {
     expect(input.value).toEqual('Hello world!');
   });
 });
+
+const { StoryWithDecoratorUseHook } = composeStories(stories);
+
+test('renders with decorator use hooks api.', () => {
+  render(<StoryWithDecoratorUseHook>Hello world</StoryWithDecoratorUseHook>);
+  const decoratorElement = screen.getByText(/args.size:large/i);
+  expect(decoratorElement).not.toBeNull();
+  const buttonElement = screen.getByText(/Hello world/i);
+  expect(buttonElement).not.toBeNull();
+});
+
+test('renders with decorator use hooks api, and args.', () => {
+  render(<StoryWithDecoratorUseHook size='small'>Hello world</StoryWithDecoratorUseHook>);
+  const decoratorElement = screen.getByText(/args.size:small/i);
+  expect(decoratorElement).not.toBeNull();
+  const buttonElement = screen.getByText(/Hello world/i);
+  expect(buttonElement).not.toBeNull();
+});


### PR DESCRIPTION
Issue: #30 

## What Changed

Fixed the following error when using the hooks function (ex. useArg) in the decorator function.

```
      Error: Uncaught [Error: Storybook preview hooks can only be called inside decorators and story functions.]
```

## Checklist

Check the ones applicable to your change:

- [X] Tests are updated
- [X] Documentation is updated

## Change Type

Indicate the type of change your pull request is:

- [ ] `documentation`
- [X] `patch`
- [ ] `minor`
- [ ] `major`
