### PR TITLE
Add test for handling csf3 `name` -> `storyName`

### DIFF
--- a/example/src/__snapshots__/internals.test.tsx.snap
+++ b/example/src/__snapshots__/internals.test.tsx.snap
@@ -143,3 +143,18 @@ exports[`Renders WithLocale story 1`] = `
   </div>
 </body>
 `;
+
+exports[`Renders custom name story 1`] = `
+<body>
+  <div>
+    <div>
+      Locale: 
+      en
+    </div>
+    <button
+      class="storybook-button storybook-button--medium storybook-button--secondary"
+      type="button"
+    />
+  </div>
+</body>
+`;

--- a/example/src/components/Button.stories.tsx
+++ b/example/src/components/Button.stories.tsx
@@ -99,3 +99,8 @@ export const StoryWithDecoratorUseHook: CSF3Story<ButtonProps> = {
     }
   ]
 };
+
+export const StoryWithName: CSF3Story<ButtonProps> = {
+  name: "custom name",
+  args: {}
+}

--- a/example/src/internals.test.tsx
+++ b/example/src/internals.test.tsx
@@ -37,6 +37,11 @@ test('should pass with decorators that need addons channel', () => {
   expect(buttonElement).not.toBeNull();
 });
 
+test('should convert a csf3 name to storyName', () => {
+  const ComposedStoryWithName = composeStory(stories.StoryWithName, stories.default);
+  expect(ComposedStoryWithName.storyName).toBe('custom name');
+});
+
 describe('Unsupported formats', () => {
   test('should throw error StoryFn.story notation', () => {
     const UnsupportedStory = () => <div>hello world</div>;


### PR DESCRIPTION
Issue: https://github.com/storybookjs/testing-react/issues/107

## What Changed

Just added a small test to document the conversion of csf3 `name` to `storyName`.

## Checklist

Check the ones applicable to your change:

- [X] Tests are updated
- [ ] Documentation is updated

## Change Type

Indicate the type of change your pull request is:

- [X] `documentation`
- [ ] `patch`
- [ ] `minor`
- [ ] `major`
