### PR TITLE
Fix path for export WebProjectAnnotations

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,5 @@
 import type { BaseAnnotations, BaseStoryFn as OriginalBaseStoryFn } from '@storybook/addons';
-import type { WebProjectAnnotations } from '@storybook/preview-web';
+import type { WebProjectAnnotations } from '@storybook/store';
 import type { StoryFn as OriginalStoryFn, StoryObj, Meta, Args,StoryContext, ReactFramework } from '@storybook/react';
 import type { ReactElement } from 'react';
 


### PR DESCRIPTION
Issue: #18531
https://github.com/storybookjs/storybook/discussions/18531
## What Changed
When using the library to test stories in a TS project, the build breaks because the import path of type WebProjectAnnotations was incorrect, with this change the problem is solved.

![image](https://user-images.githubusercontent.com/46652285/188685299-6c14e1be-8df0-4fde-b256-df78b198dd72.png)

## Checklist

Check the ones applicable to your change:

- [ ] Tests are updated
- [ ] Documentation is updated

## Change Type

Indicate the type of change your pull request is:

- [ ] `documentation`
- [x] `patch`
- [ ] `minor`
- [ ] `major`
