### PR TITLE
fix: `setChannel` is not a function

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 import { defaultDecorateStory, combineParameters } from '@storybook/client-api';
-import addons, { applyHooks, HooksContext, mockChannel } from '@storybook/addons';
+import { addons, applyHooks, HooksContext, mockChannel } from '@storybook/addons';
 import type { Meta, StoryContext, ReactFramework } from '@storybook/react';
 import { isExportStory } from '@storybook/csf'
 


### PR DESCRIPTION
TypeError: `addons__default.setChannel` is not a function

Issue: https://github.com/storybookjs/storybook/issues/20971

## What Changed

https://github.com/storybookjs/storybook/blob/next/MIGRATION.md#no-more-default-export-from-storybookaddons

![No more default export from @storybookjs/addons](https://user-images.githubusercontent.com/31362988/217153840-7711ccb1-e06b-4988-ad57-da932957bd9e.png)

<!-- Insert a description below -->

## Checklist

Check the ones applicable to your change:

- [ ] Tests are updated
- [ ] Documentation is updated

## Change Type

Indicate the type of change your pull request is:

- [ ] `documentation`
- [x] `patch`
- [ ] `minor`
- [ ] `major`
